### PR TITLE
Remove dependence on hardcoded URL

### DIFF
--- a/main.js
+++ b/main.js
@@ -35,7 +35,6 @@ define(function (require, exports, module) {
 	var Debugger = require("Debugger");
 	var $Debugger = $(Debugger);
 
-	var extensionPath = "extensions/user/Debugger";
 	var $style;
 
 
@@ -91,8 +90,9 @@ define(function (require, exports, module) {
 	/** Init Functions *******************************************************/
 	// load the CSS style
 	function loadStyle() {
+		var lessPath = require.toUrl('./Debugger.less');
 		var request = new XMLHttpRequest();
-		request.open("GET", extensionPath + "/Debugger.less", true);
+		request.open("GET", lessPath, true);
 		request.onload = function onLoad(event) {
 			var parser = new less.Parser();
 			parser.parse(request.responseText, function onParse(err, tree) {


### PR DESCRIPTION
`require.toUrl` can be used to get module-relative URLs for resources.

Also fixed a space/tab issue (converted a few spaces to tabs so file is consistent)
